### PR TITLE
VDP-25387 Adding JSON to fileformat in ETLFileImportStepDTO class

### DIFF
--- a/src/main/java/org/vena/etltool/entities/ETLFileImportStepDTO.java
+++ b/src/main/java/org/vena/etltool/entities/ETLFileImportStepDTO.java
@@ -2,7 +2,7 @@ package org.vena.etltool.entities;
 
 public abstract class ETLFileImportStepDTO extends ETLStepDTO {
 
-	public enum FileFormat {CSV, PSV, TDF}
+	public enum FileFormat {CSV, PSV, TDF, JSON}
 
 	private DataType dataType;
 


### PR DESCRIPTION
Fix:
Based on the SQL + ETL tool architecture, using the ETL tool in SQL staging, when the job document is returned from the ETL Tool, as there is a new file format supported in ETL jobs (JSON), this file format is not part of the existing file format for the ETLFileImportStepDTO , thus errors out reading the job response from vena. 


This code change adds the JSON file format to the File Import Step DTO 

Customer visible change [REQUIRED: pick one]
No